### PR TITLE
Use thermostat ID as name if name isn't set

### DIFF
--- a/custom_components/uponor/__init__.py
+++ b/custom_components/uponor/__init__.py
@@ -113,6 +113,8 @@ class UponorStateProxy:
         var = 'cust_' + thermostat + '_name'
         if var in self._data:
             return self._data[var]
+        
+        return thermostat
 
     def get_status(self, thermostat):
         var = thermostat + '_stat_battery_error'


### PR DESCRIPTION
The Uponor Smatrix Pulse system lets you set custom room (read: thermostat) names through its app. If you haven't set any names, the current code won't return any names. This commit changes that: when asking for a thermostat's name, you'll now get the thermostat's ID - instead of an empty string - if it doesn't have a custom name set.