### PR TITLE
Allows multiple entries to be added for the integration

### DIFF
--- a/custom_components/uponor/__init__.py
+++ b/custom_components/uponor/__init__.py
@@ -1,19 +1,12 @@
-from datetime import timedelta
 import math
-import ipaddress
-import requests
-import voluptuous as vol
 import logging
 
 from homeassistant.core import HomeAssistant
 from homeassistant.config_entries import ConfigEntry
 
-from homeassistant.const import CONF_HOST, CONF_NAME
-import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.discovery import async_load_platform
+from homeassistant.const import CONF_HOST
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.event import async_track_time_interval
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from UponorJnap import UponorJnap
 
 from .const import (

--- a/custom_components/uponor/__init__.py
+++ b/custom_components/uponor/__init__.py
@@ -38,7 +38,7 @@ from .const import (
 )
 
 from .helper import (
-    get_unique_id_from
+    get_unique_id_from_config_entry
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -53,7 +53,7 @@ async def async_setup(hass: HomeAssistant, config: dict):
 
 async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry):
     host = config_entry.data[CONF_HOST]
-    unique_id = get_unique_id_from(config_entry.data[CONF_NAME])
+    unique_id = get_unique_id_from_config_entry(config_entry)
     store = hass.helpers.storage.Store(STORAGE_VERSION, STORAGE_KEY)
 
     state_proxy = await hass.async_add_executor_job(lambda: UponorStateProxy(hass, host, store, unique_id))

--- a/custom_components/uponor/climate.py
+++ b/custom_components/uponor/climate.py
@@ -28,17 +28,15 @@ from .const import (
     DEVICE_MANUFACTURER
 )
 
-from homeassistant.const import CONF_NAME
-
 from .helper import (
-    get_unique_id_from
+    get_unique_id_from_config_entry
 )
 
 _LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(hass, entry, async_add_entities):
-    unique_id = get_unique_id_from(entry.data[CONF_NAME])
+    unique_id = get_unique_id_from_config_entry(entry)
 
     state_proxy = hass.data[unique_id]["state_proxy"]
 

--- a/custom_components/uponor/config_flow.py
+++ b/custom_components/uponor/config_flow.py
@@ -1,6 +1,5 @@
 from homeassistant import config_entries
 import voluptuous as vol
-import homeassistant.helpers.config_validation as cv
 import logging
 
 from UponorJnap import UponorJnap
@@ -13,7 +12,6 @@ from homeassistant.const import (
 from .const import (
     DOMAIN,
     CONF_UNIQUE_ID,
-    SIGNAL_UPONOR_STATE_UPDATE,
     DEVICE_MANUFACTURER
 )
 

--- a/custom_components/uponor/config_flow.py
+++ b/custom_components/uponor/config_flow.py
@@ -12,11 +12,14 @@ from homeassistant.const import (
 
 from .const import (
     DOMAIN,
+    CONF_UNIQUE_ID,
     SIGNAL_UPONOR_STATE_UPDATE,
     DEVICE_MANUFACTURER
 )
 
 from .helper import (
+    create_unique_id_from_user_input,
+    generate_unique_id_from_user_input,
     get_unique_id_from
 )
 
@@ -34,13 +37,16 @@ class DomainConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             {
                 vol.Required(CONF_HOST): str,
                 vol.Required(CONF_NAME, default=DEVICE_MANUFACTURER): str,
+                vol.Optional(CONF_UNIQUE_ID): str
             }
         )
 
     async def async_step_user(self, user_input=None):
         """Handle the initial step."""
         if user_input is not None:
-            unique_id = get_unique_id_from(user_input[CONF_NAME])
+            unique_id = create_unique_id_from_user_input(user_input)
+            if unique_id is None:
+                unique_id = generate_unique_id_from_user_input(user_input)
 
             await self.async_set_unique_id(unique_id)
             self._abort_if_unique_id_configured()

--- a/custom_components/uponor/config_flow.py
+++ b/custom_components/uponor/config_flow.py
@@ -16,6 +16,10 @@ from .const import (
     DEVICE_MANUFACTURER
 )
 
+from .helper import (
+    get_unique_id_from
+)
+
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -36,7 +40,9 @@ class DomainConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_user(self, user_input=None):
         """Handle the initial step."""
         if user_input is not None:
-            await self.async_set_unique_id(DOMAIN)
+            unique_id = get_unique_id_from(user_input[CONF_NAME])
+
+            await self.async_set_unique_id(unique_id)
             self._abort_if_unique_id_configured()
 
             try:

--- a/custom_components/uponor/config_flow.py
+++ b/custom_components/uponor/config_flow.py
@@ -19,8 +19,7 @@ from .const import (
 
 from .helper import (
     create_unique_id_from_user_input,
-    generate_unique_id_from_user_input,
-    get_unique_id_from
+    generate_unique_id_from_user_input_conf_name,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -46,7 +45,7 @@ class DomainConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             unique_id = create_unique_id_from_user_input(user_input)
             if unique_id is None:
-                unique_id = generate_unique_id_from_user_input(user_input)
+                unique_id = generate_unique_id_from_user_input_conf_name(user_input)
 
             await self.async_set_unique_id(unique_id)
             self._abort_if_unique_id_configured()

--- a/custom_components/uponor/const.py
+++ b/custom_components/uponor/const.py
@@ -1,5 +1,7 @@
 from datetime import timedelta
 
+CONF_UNIQUE_ID = "unique_id"
+
 DOMAIN = "uponor"
 
 SIGNAL_UPONOR_STATE_UPDATE = "uponor_state_update"

--- a/custom_components/uponor/helper.py
+++ b/custom_components/uponor/helper.py
@@ -1,6 +1,25 @@
 from .const import (
-    DOMAIN
+    DOMAIN,
+    CONF_UNIQUE_ID
 )
+
+from homeassistant.const import (
+    CONF_NAME
+)
+
+
+def create_unique_id_from_user_input(user_input):
+    if CONF_UNIQUE_ID not in user_input and user_input[CONF_UNIQUE_ID] != "":
+        return user_input[CONF_UNIQUE_ID]
+
+    return None
+
+
+def generate_unique_id_from_user_input(user_input):
+    conf_name = user_input[CONF_NAME]
+    raw_unique_id = DOMAIN + "_" + conf_name
+    cleaned_unique_id = raw_unique_id.replace(" ", "_").lower()
+    return cleaned_unique_id
 
 
 def get_unique_id_from(conf_name: str):

--- a/custom_components/uponor/helper.py
+++ b/custom_components/uponor/helper.py
@@ -1,0 +1,11 @@
+from .const import (
+    DOMAIN
+)
+
+
+def get_unique_id_from(conf_name: str):
+
+    raw_unique_id = DOMAIN + "_" + conf_name
+    cleaned_unique_id = raw_unique_id.replace(" ", "_").lower()
+
+    return cleaned_unique_id

--- a/custom_components/uponor/helper.py
+++ b/custom_components/uponor/helper.py
@@ -3,6 +3,8 @@ from .const import (
     CONF_UNIQUE_ID
 )
 
+from homeassistant.config_entries import ConfigEntry
+
 from homeassistant.const import (
     CONF_NAME
 )
@@ -15,16 +17,12 @@ def create_unique_id_from_user_input(user_input):
     return None
 
 
-def generate_unique_id_from_user_input(user_input):
+def generate_unique_id_from_user_input_conf_name(user_input):
     conf_name = user_input[CONF_NAME]
     raw_unique_id = DOMAIN + "_" + conf_name
     cleaned_unique_id = raw_unique_id.replace(" ", "_").lower()
     return cleaned_unique_id
 
 
-def get_unique_id_from(conf_name: str):
-
-    raw_unique_id = DOMAIN + "_" + conf_name
-    cleaned_unique_id = raw_unique_id.replace(" ", "_").lower()
-
-    return cleaned_unique_id
+def get_unique_id_from_config_entry(config_entry : ConfigEntry):
+    return config_entry.unique_id

--- a/custom_components/uponor/switch.py
+++ b/custom_components/uponor/switch.py
@@ -4,26 +4,32 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
 from homeassistant.const import CONF_NAME
 from .const import (
-    DOMAIN,
     SIGNAL_UPONOR_STATE_UPDATE,
     DEVICE_MANUFACTURER
 )
 
+from .helper import (
+    get_unique_id_from
+)
+
 
 async def async_setup_entry(hass, entry, async_add_entities):
-    state_proxy = hass.data[DOMAIN]["state_proxy"]
-    entities = [AwaySwitch(state_proxy, entry.data[CONF_NAME])]
+    unique_id = get_unique_id_from(entry.data[CONF_NAME])
+
+    state_proxy = hass.data[unique_id]["state_proxy"]
+    entities = [AwaySwitch(unique_id, state_proxy, entry.data[CONF_NAME])]
 
     if state_proxy.is_cool_available():
-        entities.append(CoolSwitch(state_proxy, entry.data[CONF_NAME]))
+        entities.append(CoolSwitch(unique_id, state_proxy, entry.data[CONF_NAME]))
 
     async_add_entities(entities)
 
 
 class AwaySwitch(SwitchEntity):
-    def __init__(self, state_proxy, name):
+    def __init__(self, unique_instance_id, state_proxy, name):
         self._state_proxy = state_proxy
         self._name = name
+        self._unique_instance_id = unique_instance_id
 
     @property
     def name(self) -> str:
@@ -63,7 +69,7 @@ class AwaySwitch(SwitchEntity):
     @property
     def device_info(self):
         return {
-            "identifiers": {(DOMAIN, "c")},
+            "identifiers": {(self._unique_instance_id, "c")},
             "name": self._name,
             "manufacturer": DEVICE_MANUFACTURER,
             "model": self._state_proxy.get_model(),
@@ -71,9 +77,10 @@ class AwaySwitch(SwitchEntity):
 
 
 class CoolSwitch(SwitchEntity):
-    def __init__(self, state_proxy, name):
+    def __init__(self, unique_instance_id, state_proxy, name):
         self._state_proxy = state_proxy
         self._name = name
+        self._unique_instance_id = unique_instance_id
 
     @property
     def name(self) -> str:
@@ -113,7 +120,7 @@ class CoolSwitch(SwitchEntity):
     @property
     def device_info(self):
         return {
-            "identifiers": {(DOMAIN, "c")},
+            "identifiers": {(self._unique_instance_id, "c")},
             "name": self._name,
             "manufacturer": DEVICE_MANUFACTURER,
             "model": self._state_proxy.get_model(),

--- a/custom_components/uponor/switch.py
+++ b/custom_components/uponor/switch.py
@@ -9,12 +9,12 @@ from .const import (
 )
 
 from .helper import (
-    get_unique_id_from
+    get_unique_id_from_config_entry
 )
 
 
 async def async_setup_entry(hass, entry, async_add_entities):
-    unique_id = get_unique_id_from(entry.data[CONF_NAME])
+    unique_id = get_unique_id_from_config_entry(entry)
 
     state_proxy = hass.data[unique_id]["state_proxy"]
     entities = [AwaySwitch(unique_id, state_proxy, entry.data[CONF_NAME])]

--- a/custom_components/uponor/translations/en.json
+++ b/custom_components/uponor/translations/en.json
@@ -6,7 +6,8 @@
         "description": "Set up Uponor heating/cooling system",
         "data": {
           "host": "Host or IP address of the Uponor controller",
-          "name": "Name of the integration instance"
+          "name": "Name of the integration instance",
+          "unique_id": "Optional unique identifier (must be unique across entries)"
         }
       },
       "rooms": {


### PR DESCRIPTION
Currently the DOMAIN (uponor) is set as the unique_id. 
This prevents multiple entries to be added.

Users can optionally set a unique_id of their own preference or leave the field empty for it to be auto-generated.

The `async_setup` in `__init__.py` has been disabled, and seems like dead code. 

Disclaimer: I am not familiar with Python and very inexperienced with the custom_component things in HA.
Open to suggestions / improvements.

Fixes #34