### PR TITLE
Fix #50 TypeError: UponorStateProxy.async_update() takes 1 positional argument but 2 were given

### DIFF
--- a/custom_components/uponor/__init__.py
+++ b/custom_components/uponor/__init__.py
@@ -283,7 +283,7 @@ class UponorStateProxy:
 
     # Rest
 
-    async def async_update(self):
+    async def async_update(self,_=None):
         self._data = await self._hass.async_add_executor_job(lambda: self._client.get_data())
 
     def set_variable(self, var_name, var_value):


### PR DESCRIPTION
Recover second argument in UponorStateProxy.async_update(), with None default value as nothing is done with the argument that scheduler passes to it