### PR TITLE
Add Floor Temp, Humidity, Current Temp Sensors + Logging

### DIFF
--- a/custom_components/uponor/__init__.py
+++ b/custom_components/uponor/__init__.py
@@ -146,7 +146,6 @@ class UponorStateProxy:
 
     def has_humidity_sensor(self, thermostat):
         var = thermostat + '_rh'
-        _LOGGER.debug(self._data)
         return var in self._data
         
     def get_humidity(self, thermostat):

--- a/custom_components/uponor/__init__.py
+++ b/custom_components/uponor/__init__.py
@@ -144,6 +144,10 @@ class UponorStateProxy:
         if var in self._data:
             return round((int(self._data[var]) - 320) / 18, 1)
 
+    def has_humidity_sensor(self, thermostat):
+        var = thermostat + '_rh'
+        return var in self._data
+        
     def get_humidity(self, thermostat):
         var = thermostat + '_rh'
         if var in self._data and int(self._data[var]) >= TOO_LOW_HUMIDITY_LIMIT:

--- a/custom_components/uponor/__init__.py
+++ b/custom_components/uponor/__init__.py
@@ -146,7 +146,7 @@ class UponorStateProxy:
 
     def has_humidity_sensor(self, thermostat):
         var = thermostat + '_rh'
-        return var in self._data
+        return var in self._data and int(self._data[var]) != 0
         
     def get_humidity(self, thermostat):
         var = thermostat + '_rh'

--- a/custom_components/uponor/__init__.py
+++ b/custom_components/uponor/__init__.py
@@ -146,6 +146,7 @@ class UponorStateProxy:
 
     def has_humidity_sensor(self, thermostat):
         var = thermostat + '_rh'
+        _LOGGER.debug(self._data)
         return var in self._data
         
     def get_humidity(self, thermostat):

--- a/custom_components/uponor/__init__.py
+++ b/custom_components/uponor/__init__.py
@@ -35,7 +35,7 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS = [Platform.CLIMATE, Platform.SWITCH]
+PLATFORMS = [Platform.CLIMATE, Platform.SWITCH, Platform.SENSOR]
 
 async def async_setup(hass: HomeAssistant, config: dict):
     hass.data.setdefault(DOMAIN, {})
@@ -79,7 +79,7 @@ async def async_update_options(hass: HomeAssistant, entry: ConfigEntry) -> None:
 async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     _LOGGER.debug("Unloading setup entry: %s, data: %s, options: %s", config_entry.entry_id, config_entry.data, config_entry.options)
-    unload_ok = await hass.config_entries.async_unload_platforms(config_entry, [Platform.SWITCH, Platform.CLIMATE])
+    unload_ok = await hass.config_entries.async_unload_platforms(config_entry, [Platform.SWITCH, Platform.CLIMATE, Platform.SENSOR])
     return unload_ok
 
 class UponorStateProxy:
@@ -148,6 +148,19 @@ class UponorStateProxy:
         var = thermostat + '_rh'
         if var in self._data and int(self._data[var]) >= TOO_LOW_HUMIDITY_LIMIT:
             return int(self._data[var])
+        
+    def has_floor_temperature(self, thermostat):
+        var = thermostat + '_external_temperature'
+        return var in self._data and int(self._data[var]) != 32767
+
+    def get_floor_temperature(self, thermostat):
+        var = thermostat + '_external_temperature'
+        if var in self._data:
+            temp = int(self._data[var])
+            if temp != 32767 and temp <= TOO_HIGH_TEMP_LIMIT:
+                return round((temp - 320) / 18, 1)
+        return None
+
 
     # Temperature setpoint
 

--- a/custom_components/uponor/sensor.py
+++ b/custom_components/uponor/sensor.py
@@ -70,6 +70,11 @@ class UponorHumiditySensor(SensorEntity):
         }
 
     @property
+    def available(self):
+        """Return True if the sensor is available."""
+        return self._state_proxy.is_thermostat_connected(self._thermostat) && self._state_proxy.has_humidity_sensor(self._thermostat)
+
+    @property
     def native_value(self):
         return self._state_proxy.get_humidity(self._thermostat)
 

--- a/custom_components/uponor/sensor.py
+++ b/custom_components/uponor/sensor.py
@@ -1,5 +1,5 @@
-from homeassistant.components.sensor import SensorEntity
-from homeassistant.const import UnitOfTemperature
+from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
+from homeassistant.const import UnitOfTemperature, PERCENTAGE
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
@@ -55,7 +55,7 @@ class UponorHumiditySensor(SensorEntity):
         self._thermostat = thermostat
         self._attr_name = f"{state_proxy.get_room_name(thermostat)} humidity"
         self._attr_unique_id = f"{state_proxy.get_thermostat_id(thermostat)}_rh"
-        self._attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
+        self._attr_device_class = SensorDeviceClass.HUMIDITY
 
     @property
     def device_info(self):

--- a/custom_components/uponor/sensor.py
+++ b/custom_components/uponor/sensor.py
@@ -60,11 +60,6 @@ class UponorHumiditySensor(SensorEntity):
         self._attr_native_unit_of_measurement = PERCENTAGE
 
     @property
-    def available(self):
-        """Return True if the sensor is available."""
-        return self._state_proxy.is_thermostat_connected(self._thermostat)
-
-    @property
     def device_info(self):
         return {
             "identifiers": {(DOMAIN, self._state_proxy.get_thermostat_id(self._thermostat))},

--- a/custom_components/uponor/sensor.py
+++ b/custom_components/uponor/sensor.py
@@ -12,7 +12,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
     for thermostat in hass.data[DOMAIN]["thermostats"]:
         if state_proxy.has_floor_temperature(thermostat):
             entities.append(UponorFloorTemperatureSensor(state_proxy, thermostat))
-        if state_proxy.has_humidity_sensor(thermostat):
+        if state_proxy.has_humidity_sensor(state_proxy, thermostat):
             entities.append(UponorHumiditySensor(state_proxy, thermostat))
     
     async_add_entities(entities, update_before_add=False)

--- a/custom_components/uponor/sensor.py
+++ b/custom_components/uponor/sensor.py
@@ -12,6 +12,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
     for thermostat in hass.data[DOMAIN]["thermostats"]:
         if state_proxy.has_floor_temperature(thermostat):
             entities.append(UponorFloorTemperatureSensor(state_proxy, thermostat))
+            entities.append(UponorHumiditySensor(state_proxy, thermostat))
     
     async_add_entities(entities, update_before_add=False)
 
@@ -21,6 +22,39 @@ class UponorFloorTemperatureSensor(SensorEntity):
         self._thermostat = thermostat
         self._attr_name = f"{state_proxy.get_room_name(thermostat)} Floor Temperature"
         self._attr_unique_id = f"{state_proxy.get_thermostat_id(thermostat)}_floor_temp"
+        self._attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
+
+    @property
+    def device_info(self):
+        return {
+            "identifiers": {(DOMAIN, self._state_proxy.get_thermostat_id(self._thermostat))},
+            "name": self._state_proxy.get_room_name(self._thermostat),
+            "manufacturer": "Uponor",
+            "model": self._state_proxy.get_model(),
+            "sw_version": self._state_proxy.get_version(self._thermostat)
+        }
+
+    @property
+    def native_value(self):
+        return self._state_proxy.get_floor_temperature(self._thermostat)
+
+    async def async_added_to_hass(self):
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass, SIGNAL_UPONOR_STATE_UPDATE, self._update_callback
+            )
+        )
+
+    @callback
+    def _update_callback(self):
+        self.async_write_ha_state()
+
+class UponorHumiditySensor(SensorEntity):
+    def __init__(self, state_proxy, thermostat):
+        self._state_proxy = state_proxy
+        self._thermostat = thermostat
+        self._attr_name = f"{state_proxy.get_room_name(thermostat)} humidity"
+        self._attr_unique_id = f"{state_proxy.get_thermostat_id(thermostat)}_rh"
         self._attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
 
     @property

--- a/custom_components/uponor/sensor.py
+++ b/custom_components/uponor/sensor.py
@@ -12,6 +12,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
     for thermostat in hass.data[DOMAIN]["thermostats"]:
         if state_proxy.has_floor_temperature(thermostat):
             entities.append(UponorFloorTemperatureSensor(state_proxy, thermostat))
+        if state_proxy.has_humidity_sensor(thermostat):
             entities.append(UponorHumiditySensor(state_proxy, thermostat))
     
     async_add_entities(entities, update_before_add=False)
@@ -57,6 +58,11 @@ class UponorHumiditySensor(SensorEntity):
         self._attr_unique_id = f"{state_proxy.get_thermostat_id(thermostat)}_rh"
         self._attr_device_class = SensorDeviceClass.HUMIDITY
         self._attr_native_unit_of_measurement = PERCENTAGE
+
+    @property
+    def available(self):
+        """Return True if the sensor is available."""
+        return self._state_proxy.is_thermostat_connected(self._thermostat)
 
     @property
     def device_info(self):

--- a/custom_components/uponor/sensor.py
+++ b/custom_components/uponor/sensor.py
@@ -1,29 +1,42 @@
-from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
+import logging
+
+from homeassistant.components.sensor import SensorEntity, SensorDeviceClass, SensorStateClass
 from homeassistant.const import UnitOfTemperature, PERCENTAGE
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
 from .const import DOMAIN, SIGNAL_UPONOR_STATE_UPDATE
 
+_LOGGER = logging.getLogger(__name__)  # Lägg till detta
 async def async_setup_entry(hass, entry, async_add_entities):
     state_proxy = hass.data[DOMAIN]["state_proxy"]
 
     entities = []
     for thermostat in hass.data[DOMAIN]["thermostats"]:
+        room_name = state_proxy.get_room_name(thermostat)
+        _LOGGER.debug(f"Adding sensors for {room_name} (thermostat ID: {thermostat})")
+        entities.append(UponorRoomCurrentTemperatureSensor(state_proxy, thermostat))
+        
         if state_proxy.has_floor_temperature(thermostat):
             entities.append(UponorFloorTemperatureSensor(state_proxy, thermostat))
+            _LOGGER.debug(f"Added floor sensor for: {room_name}")
+        
         if state_proxy.has_humidity_sensor(thermostat):
             entities.append(UponorHumiditySensor(state_proxy, thermostat))
+            _LOGGER.debug(f"Added humidity sensor for: {room_name}")
     
+    _LOGGER.debug(f"Total number of sensors added: {len(entities)}")
     async_add_entities(entities, update_before_add=False)
 
 class UponorFloorTemperatureSensor(SensorEntity):
+
     def __init__(self, state_proxy, thermostat):
         self._state_proxy = state_proxy
         self._thermostat = thermostat
         self._attr_name = f"{state_proxy.get_room_name(thermostat)} Floor Temperature"
         self._attr_unique_id = f"{state_proxy.get_thermostat_id(thermostat)}_floor_temp"
         self._attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
+        self._attr_state_class = SensorStateClass.MEASUREMENT
 
     @property
     def device_info(self):
@@ -45,9 +58,47 @@ class UponorFloorTemperatureSensor(SensorEntity):
                 self.hass, SIGNAL_UPONOR_STATE_UPDATE, self._update_callback
             )
         )
-
     @callback
     def _update_callback(self):
+        """Update sensor state. when data updates"""
+        _LOGGER.debug(f"Updating state for {self._attr_name} with ID {self._attr_unique_id}")
+        self.async_write_ha_state()      
+
+class UponorRoomCurrentTemperatureSensor(SensorEntity):
+
+    def __init__(self, state_proxy, thermostat):
+        self._state_proxy = state_proxy
+        self._thermostat = thermostat
+        self._attr_name = f"{state_proxy.get_room_name(thermostat)} Current Temperature"
+        self._attr_unique_id = f"{state_proxy.get_thermostat_id(thermostat)}_current_temp"
+        self._attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
+        self._attr_state_class = SensorStateClass.MEASUREMENT
+        
+
+    @property
+    def device_info(self):
+        return {
+            "identifiers": {(DOMAIN, self._state_proxy.get_thermostat_id(self._thermostat))},
+            "name": self._state_proxy.get_room_name(self._thermostat),
+            "manufacturer": "Uponor",
+            "model": self._state_proxy.get_model(),
+            "sw_version": self._state_proxy.get_version(self._thermostat)
+        }
+
+    @property
+    def native_value(self):
+        return self._state_proxy.get_temperature(self._thermostat)
+
+    async def async_added_to_hass(self):
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass, SIGNAL_UPONOR_STATE_UPDATE, self._update_callback
+            )
+        )
+    @callback
+    def _update_callback(self):
+        """Update sensor state. when data updates"""
+        _LOGGER.debug(f"Updating state for {self._attr_name} with ID {self._attr_unique_id}")
         self.async_write_ha_state()
 
 class UponorHumiditySensor(SensorEntity):
@@ -58,6 +109,7 @@ class UponorHumiditySensor(SensorEntity):
         self._attr_unique_id = f"{state_proxy.get_thermostat_id(thermostat)}_rh"
         self._attr_device_class = SensorDeviceClass.HUMIDITY
         self._attr_native_unit_of_measurement = PERCENTAGE
+        self._attr_state_class = SensorStateClass.MEASUREMENT 
 
     @property
     def device_info(self):
@@ -87,4 +139,5 @@ class UponorHumiditySensor(SensorEntity):
 
     @callback
     def _update_callback(self):
+        _LOGGER.debug(f"Updating state for {self._attr_name} with ID {self._attr_unique_id}")
         self.async_write_ha_state()

--- a/custom_components/uponor/sensor.py
+++ b/custom_components/uponor/sensor.py
@@ -69,7 +69,7 @@ class UponorHumiditySensor(SensorEntity):
 
     @property
     def native_value(self):
-        return self._state_proxy.get_floor_temperature(self._thermostat)
+        return self._state_proxy.get_humidity(self._thermostat)
 
     async def async_added_to_hass(self):
         self.async_on_remove(

--- a/custom_components/uponor/sensor.py
+++ b/custom_components/uponor/sensor.py
@@ -12,7 +12,8 @@ async def async_setup_entry(hass, entry, async_add_entities):
     for thermostat in hass.data[DOMAIN]["thermostats"]:
         if state_proxy.has_floor_temperature(thermostat):
             entities.append(UponorFloorTemperatureSensor(state_proxy, thermostat))
-        entities.append(UponorHumiditySensor(state_proxy, thermostat))
+        if state_proxy.has_humidity_sensor(thermostat):
+            entities.append(UponorHumiditySensor(state_proxy, thermostat))
     
     async_add_entities(entities, update_before_add=False)
 

--- a/custom_components/uponor/sensor.py
+++ b/custom_components/uponor/sensor.py
@@ -56,6 +56,7 @@ class UponorHumiditySensor(SensorEntity):
         self._attr_name = f"{state_proxy.get_room_name(thermostat)} humidity"
         self._attr_unique_id = f"{state_proxy.get_thermostat_id(thermostat)}_rh"
         self._attr_device_class = SensorDeviceClass.HUMIDITY
+        self._attr_native_unit_of_measurement = PERCENTAGE
 
     @property
     def device_info(self):

--- a/custom_components/uponor/sensor.py
+++ b/custom_components/uponor/sensor.py
@@ -1,0 +1,49 @@
+from homeassistant.components.sensor import SensorEntity
+from homeassistant.const import UnitOfTemperature
+from homeassistant.core import callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+
+from .const import DOMAIN, SIGNAL_UPONOR_STATE_UPDATE
+
+async def async_setup_entry(hass, entry, async_add_entities):
+    state_proxy = hass.data[DOMAIN]["state_proxy"]
+
+    entities = []
+    for thermostat in hass.data[DOMAIN]["thermostats"]:
+        if state_proxy.has_floor_temperature(thermostat):
+            entities.append(UponorFloorTemperatureSensor(state_proxy, thermostat))
+    
+    async_add_entities(entities, update_before_add=False)
+
+class UponorFloorTemperatureSensor(SensorEntity):
+    def __init__(self, state_proxy, thermostat):
+        self._state_proxy = state_proxy
+        self._thermostat = thermostat
+        self._attr_name = f"{state_proxy.get_room_name(thermostat)} Floor Temperature"
+        self._attr_unique_id = f"{state_proxy.get_thermostat_id(thermostat)}_floor_temp"
+        self._attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
+
+    @property
+    def device_info(self):
+        return {
+            "identifiers": {(DOMAIN, self._state_proxy.get_thermostat_id(self._thermostat))},
+            "name": self._state_proxy.get_room_name(self._thermostat),
+            "manufacturer": "Uponor",
+            "model": self._state_proxy.get_model(),
+            "sw_version": self._state_proxy.get_version(self._thermostat)
+        }
+
+    @property
+    def native_value(self):
+        return self._state_proxy.get_floor_temperature(self._thermostat)
+
+    async def async_added_to_hass(self):
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass, SIGNAL_UPONOR_STATE_UPDATE, self._update_callback
+            )
+        )
+
+    @callback
+    def _update_callback(self):
+        self.async_write_ha_state()

--- a/custom_components/uponor/sensor.py
+++ b/custom_components/uponor/sensor.py
@@ -72,7 +72,7 @@ class UponorHumiditySensor(SensorEntity):
     @property
     def available(self):
         """Return True if the sensor is available."""
-        return self._state_proxy.is_thermostat_connected(self._thermostat) and self._state_proxy.has_humidity_sensor(self._thermostat)
+        return self._state_proxy.has_humidity_sensor(self._thermostat)
 
     @property
     def native_value(self):

--- a/custom_components/uponor/sensor.py
+++ b/custom_components/uponor/sensor.py
@@ -12,8 +12,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
     for thermostat in hass.data[DOMAIN]["thermostats"]:
         if state_proxy.has_floor_temperature(thermostat):
             entities.append(UponorFloorTemperatureSensor(state_proxy, thermostat))
-        if state_proxy.has_humidity_sensor(state_proxy, thermostat):
-            entities.append(UponorHumiditySensor(state_proxy, thermostat))
+        entities.append(UponorHumiditySensor(state_proxy, thermostat))
     
     async_add_entities(entities, update_before_add=False)
 

--- a/custom_components/uponor/sensor.py
+++ b/custom_components/uponor/sensor.py
@@ -72,7 +72,7 @@ class UponorHumiditySensor(SensorEntity):
     @property
     def available(self):
         """Return True if the sensor is available."""
-        return self._state_proxy.is_thermostat_connected(self._thermostat) && self._state_proxy.has_humidity_sensor(self._thermostat)
+        return self._state_proxy.is_thermostat_connected(self._thermostat) and self._state_proxy.has_humidity_sensor(self._thermostat)
 
     @property
     def native_value(self):

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
-  "name": "Uponor Smatrix Pulse",
+  "name": "Uponor Smatrix Pulse - Test",
   "iot_class": "Local Polling",
   "render_readme": true
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
-  "name": "Uponor Smatrix Pulse - Test",
+  "name": "Uponor Smatrix Pulse",
   "iot_class": "Local Polling",
   "render_readme": true
 }


### PR DESCRIPTION
This PR adds several useful sensors in HA. Solves #55 and #56

The floor temperature or humidity sensors will only be added for thermostats that actually has floor temperature/humidity sensors working in Uponor (Room - Room Settings - Advanced Room Settings). Thanks to @vali-ballertv / @valentinlup for the humidity sensor code.

This also adds a sensor for Current temperature, for use in cards or helpers. Not to mention improved logging. Thanks to @chribba021 for that code.

<img width="865" alt="Screenshot 2024-11-13 at 18 57 56" src="https://github.com/user-attachments/assets/deb78888-c50d-4cfa-8f59-1d8d74781e57">


