### PR TITLE
Extra sensors

### DIFF
--- a/custom_components/uponor/__init__.py
+++ b/custom_components/uponor/__init__.py
@@ -59,6 +59,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry):
     def handle_set_variable(call):
         var_name = call.data.get('var_name')
         var_value = call.data.get('var_value')
+        _LOGGER.debug(f"Setting variable: {var_name} to: {var_value}")
         hass.data[DOMAIN]['state_proxy'].set_variable(var_name, var_value)
 
     hass.services.async_register(DOMAIN, "set_variable", handle_set_variable)
@@ -311,8 +312,11 @@ class UponorStateProxy:
     # Rest
     async def async_update(self,_=None):
         try:
+            _LOGGER.debug("Running  async_update to get data from Uponor thermostat.")
             self.next_sp_from_dt = dt_util.now()
             self._data = await self._hass.async_add_executor_job(lambda: self._client.get_data())
+            # For deep debug remove comment and you get the full json message.
+            # _LOGGER.debug(f"Data recieved from Uponor: {self._data}")
             self._hass.async_add_job(async_dispatcher_send, self._hass, SIGNAL_UPONOR_STATE_UPDATE)
         except Exception as ex:
             _LOGGER.error("Uponor thermostat was unable to update: %s", ex)

--- a/custom_components/uponor/__init__.py
+++ b/custom_components/uponor/__init__.py
@@ -4,6 +4,7 @@ import logging
 from homeassistant.core import HomeAssistant
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
+
 from homeassistant.const import CONF_HOST
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.event import async_track_time_interval
@@ -61,10 +62,8 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry):
         hass.data[DOMAIN]['state_proxy'].set_variable(var_name, var_value)
 
     hass.services.async_register(DOMAIN, "set_variable", handle_set_variable)
-##Split platform loading for potetial issues when adding .sensor on a old installation.
-    await hass.config_entries.async_forward_entry_setup(config_entry, Platform.CLIMATE)
-    await hass.config_entries.async_forward_entry_setup(config_entry, Platform.SWITCH)
-    await hass.config_entries.async_forward_entry_setup(config_entry, Platform.SENSOR)
+
+    await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
 
     async_track_time_interval(hass, state_proxy.async_update, SCAN_INTERVAL)
 
@@ -80,9 +79,7 @@ async def async_update_options(hass: HomeAssistant, entry: ConfigEntry) -> None:
 async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     _LOGGER.debug("Unloading setup entry: %s, data: %s, options: %s", config_entry.entry_id, config_entry.data, config_entry.options)
-    unload_ok = await hass.config_entries.async_unload_platforms(
-        config_entry, [Platform.SWITCH, Platform.CLIMATE, Platform.SENSOR]
-        )
+    unload_ok = await hass.config_entries.async_unload_platforms(config_entry, [Platform.SWITCH, Platform.CLIMATE, Platform.SENSOR])
     _LOGGER.debug(f"Unload status for Uponor platforms: {unload_ok}")  
     return unload_ok
 

--- a/custom_components/uponor/sensor.py
+++ b/custom_components/uponor/sensor.py
@@ -14,18 +14,18 @@ async def async_setup_entry(hass, entry, async_add_entities):
     entities = []
     for thermostat in hass.data[DOMAIN]["thermostats"]:
         room_name = state_proxy.get_room_name(thermostat)
-        _LOGGER.debug(f"Lägger till sensorer för {room_name} (thermostat ID: {thermostat})")
+        _LOGGER.debug(f"Adding sensors for {room_name} (thermostat ID: {thermostat})")
         entities.append(UponorRoomCurrentTemperatureSensor(state_proxy, thermostat))
         
         if state_proxy.has_floor_temperature(thermostat):
             entities.append(UponorFloorTemperatureSensor(state_proxy, thermostat))
-            _LOGGER.debug(f"Lade till golvsensor för {room_name}")
+            _LOGGER.debug(f"Added floor sensor for: {room_name}")
         
         if state_proxy.has_humidity_sensor(thermostat):
             entities.append(UponorHumiditySensor(state_proxy, thermostat))
-            _LOGGER.debug(f"Lade till luftfuktighetssensor för {room_name}")
+            _LOGGER.debug(f"Added humidity sensor for: {room_name}")
     
-    _LOGGER.debug(f"Totalt antal sensorer som läggs till: {len(entities)}")
+    _LOGGER.debug(f"Total number of sensors added: {len(entities)}")
     async_add_entities(entities, update_before_add=False)
 
 class UponorFloorTemperatureSensor(SensorEntity):
@@ -60,10 +60,10 @@ class UponorFloorTemperatureSensor(SensorEntity):
         )
     @callback
     def _update_callback(self):
-        """Uppdatera sensorns tillstånd när data ändras."""
+        """Update sensor state. when data updates"""
         _LOGGER.debug(f"Updating state for {self._attr_name} with ID {self._attr_unique_id}")
         self.async_write_ha_state()      
-          
+
 class UponorRoomCurrentTemperatureSensor(SensorEntity):
 
     def __init__(self, state_proxy, thermostat):
@@ -97,7 +97,7 @@ class UponorRoomCurrentTemperatureSensor(SensorEntity):
         )
     @callback
     def _update_callback(self):
-        """Uppdatera sensorns tillstånd när data ändras."""
+        """Update sensor state. when data updates"""
         _LOGGER.debug(f"Updating state for {self._attr_name} with ID {self._attr_unique_id}")
         self.async_write_ha_state()
 

--- a/custom_components/uponor/sensor.py
+++ b/custom_components/uponor/sensor.py
@@ -1,9 +1,7 @@
 import logging
 
-from homeassistant.components.sensor import SensorEntity
-from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
+from homeassistant.components.sensor import SensorEntity, SensorDeviceClass, SensorStateClass
 from homeassistant.const import UnitOfTemperature, PERCENTAGE
-from homeassistant.const import UnitOfTemperature
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
@@ -38,6 +36,7 @@ class UponorFloorTemperatureSensor(SensorEntity):
         self._attr_name = f"{state_proxy.get_room_name(thermostat)} Floor Temperature"
         self._attr_unique_id = f"{state_proxy.get_thermostat_id(thermostat)}_floor_temp"
         self._attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
+        self._attr_state_class = SensorStateClass.MEASUREMENT
 
     @property
     def device_info(self):
@@ -62,6 +61,7 @@ class UponorFloorTemperatureSensor(SensorEntity):
     @callback
     def _update_callback(self):
         """Uppdatera sensorns tillstånd när data ändras."""
+        _LOGGER.debug(f"Updating state for {self._attr_name} with ID {self._attr_unique_id}")
         self.async_write_ha_state()        
 class UponorRoomCurrentTemperatureSensor(SensorEntity):
 
@@ -71,6 +71,8 @@ class UponorRoomCurrentTemperatureSensor(SensorEntity):
         self._attr_name = f"{state_proxy.get_room_name(thermostat)} Current Temperature"
         self._attr_unique_id = f"{state_proxy.get_thermostat_id(thermostat)}_current_temp"
         self._attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
+        self._attr_state_class = SensorStateClass.MEASUREMENT
+        
 
     @property
     def device_info(self):
@@ -95,7 +97,9 @@ class UponorRoomCurrentTemperatureSensor(SensorEntity):
     @callback
     def _update_callback(self):
         """Uppdatera sensorns tillstånd när data ändras."""
+        _LOGGER.debug(f"Updating state for {self._attr_name} with ID {self._attr_unique_id}")
         self.async_write_ha_state()
+
 class UponorHumiditySensor(SensorEntity):
     def __init__(self, state_proxy, thermostat):
         self._state_proxy = state_proxy
@@ -104,6 +108,7 @@ class UponorHumiditySensor(SensorEntity):
         self._attr_unique_id = f"{state_proxy.get_thermostat_id(thermostat)}_rh"
         self._attr_device_class = SensorDeviceClass.HUMIDITY
         self._attr_native_unit_of_measurement = PERCENTAGE
+        self._attr_state_class = SensorStateClass.MEASUREMENT 
 
     @property
     def device_info(self):
@@ -133,4 +138,5 @@ class UponorHumiditySensor(SensorEntity):
 
     @callback
     def _update_callback(self):
+        _LOGGER.debug(f"Updating state for {self._attr_name} with ID {self._attr_unique_id}")
         self.async_write_ha_state()

--- a/custom_components/uponor/sensor.py
+++ b/custom_components/uponor/sensor.py
@@ -62,7 +62,8 @@ class UponorFloorTemperatureSensor(SensorEntity):
     def _update_callback(self):
         """Uppdatera sensorns tillstånd när data ändras."""
         _LOGGER.debug(f"Updating state for {self._attr_name} with ID {self._attr_unique_id}")
-        self.async_write_ha_state()        
+        self.async_write_ha_state()      
+          
 class UponorRoomCurrentTemperatureSensor(SensorEntity):
 
     def __init__(self, state_proxy, thermostat):

--- a/custom_components/uponor/sensor.py
+++ b/custom_components/uponor/sensor.py
@@ -1,0 +1,136 @@
+import logging
+
+from homeassistant.components.sensor import SensorEntity
+from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
+from homeassistant.const import UnitOfTemperature, PERCENTAGE
+from homeassistant.const import UnitOfTemperature
+from homeassistant.core import callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+
+from .const import DOMAIN, SIGNAL_UPONOR_STATE_UPDATE
+
+_LOGGER = logging.getLogger(__name__)  # Lägg till detta
+async def async_setup_entry(hass, entry, async_add_entities):
+    state_proxy = hass.data[DOMAIN]["state_proxy"]
+
+    entities = []
+    for thermostat in hass.data[DOMAIN]["thermostats"]:
+        room_name = state_proxy.get_room_name(thermostat)
+        _LOGGER.debug(f"Lägger till sensorer för {room_name} (thermostat ID: {thermostat})")
+        entities.append(UponorRoomCurrentTemperatureSensor(state_proxy, thermostat))
+        
+        if state_proxy.has_floor_temperature(thermostat):
+            entities.append(UponorFloorTemperatureSensor(state_proxy, thermostat))
+            _LOGGER.debug(f"Lade till golvsensor för {room_name}")
+        
+        if state_proxy.has_humidity_sensor(thermostat):
+            entities.append(UponorHumiditySensor(state_proxy, thermostat))
+            _LOGGER.debug(f"Lade till luftfuktighetssensor för {room_name}")
+    
+    _LOGGER.debug(f"Totalt antal sensorer som läggs till: {len(entities)}")
+    async_add_entities(entities, update_before_add=False)
+
+class UponorFloorTemperatureSensor(SensorEntity):
+
+    def __init__(self, state_proxy, thermostat):
+        self._state_proxy = state_proxy
+        self._thermostat = thermostat
+        self._attr_name = f"{state_proxy.get_room_name(thermostat)} Floor Temperature"
+        self._attr_unique_id = f"{state_proxy.get_thermostat_id(thermostat)}_floor_temp"
+        self._attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
+
+    @property
+    def device_info(self):
+        return {
+            "identifiers": {(DOMAIN, self._state_proxy.get_thermostat_id(self._thermostat))},
+            "name": self._state_proxy.get_room_name(self._thermostat),
+            "manufacturer": "Uponor",
+            "model": self._state_proxy.get_model(),
+            "sw_version": self._state_proxy.get_version(self._thermostat)
+        }
+
+    @property
+    def native_value(self):
+        return self._state_proxy.get_floor_temperature(self._thermostat)
+
+    async def async_added_to_hass(self):
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass, SIGNAL_UPONOR_STATE_UPDATE, self._update_callback
+            )
+        )
+    @callback
+    def _update_callback(self):
+        """Uppdatera sensorns tillstånd när data ändras."""
+        self.async_write_ha_state()        
+class UponorRoomCurrentTemperatureSensor(SensorEntity):
+
+    def __init__(self, state_proxy, thermostat):
+        self._state_proxy = state_proxy
+        self._thermostat = thermostat
+        self._attr_name = f"{state_proxy.get_room_name(thermostat)} Current Temperature"
+        self._attr_unique_id = f"{state_proxy.get_thermostat_id(thermostat)}_current_temp"
+        self._attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
+
+    @property
+    def device_info(self):
+        return {
+            "identifiers": {(DOMAIN, self._state_proxy.get_thermostat_id(self._thermostat))},
+            "name": self._state_proxy.get_room_name(self._thermostat),
+            "manufacturer": "Uponor",
+            "model": self._state_proxy.get_model(),
+            "sw_version": self._state_proxy.get_version(self._thermostat)
+        }
+
+    @property
+    def native_value(self):
+        return self._state_proxy.get_temperature(self._thermostat)
+
+    async def async_added_to_hass(self):
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass, SIGNAL_UPONOR_STATE_UPDATE, self._update_callback
+            )
+        )
+    @callback
+    def _update_callback(self):
+        """Uppdatera sensorns tillstånd när data ändras."""
+        self.async_write_ha_state()
+class UponorHumiditySensor(SensorEntity):
+    def __init__(self, state_proxy, thermostat):
+        self._state_proxy = state_proxy
+        self._thermostat = thermostat
+        self._attr_name = f"{state_proxy.get_room_name(thermostat)} humidity"
+        self._attr_unique_id = f"{state_proxy.get_thermostat_id(thermostat)}_rh"
+        self._attr_device_class = SensorDeviceClass.HUMIDITY
+        self._attr_native_unit_of_measurement = PERCENTAGE
+
+    @property
+    def device_info(self):
+        return {
+            "identifiers": {(DOMAIN, self._state_proxy.get_thermostat_id(self._thermostat))},
+            "name": self._state_proxy.get_room_name(self._thermostat),
+            "manufacturer": "Uponor",
+            "model": self._state_proxy.get_model(),
+            "sw_version": self._state_proxy.get_version(self._thermostat)
+        }
+
+    @property
+    def available(self):
+        """Return True if the sensor is available."""
+        return self._state_proxy.has_humidity_sensor(self._thermostat)
+
+    @property
+    def native_value(self):
+        return self._state_proxy.get_humidity(self._thermostat)
+
+    async def async_added_to_hass(self):
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass, SIGNAL_UPONOR_STATE_UPDATE, self._update_callback
+            )
+        )
+
+    @callback
+    def _update_callback(self):
+        self.async_write_ha_state()


### PR DESCRIPTION
Added extra sensor entities for the current room temperature for use in cards or helpers.
Will also add humidity and floor temperatur if the Thermostat reports it.

Device now includes sensors:
![Device](https://github.com/user-attachments/assets/aa7ee0bd-0b8a-42a8-a9e5-fb10ae678e79)

Creates separate senor entities for temp, 
(wanted it to make a helper with arimetic median for average indoor temp in the house)
![enteties](https://github.com/user-attachments/assets/2cca28a5-5fb8-4329-881e-d2d883dae8b4)

**Added extra debug logging, will list termostats and name on** 
[custom_components.uponor] Unloading setup entry:
e.g: data: {'host': '192.168.1.131', 'name': 'Uponor', 'c1_t1': 'Guest Room', 'c1_t2': 'Office', 
DEBUG (MainThread) [custom_components.uponor] Unload status for Uponor platforms: True
DEBUG (MainThread) [custom_components.uponor.sensor] Adding sensors for Guest Room (thermostat ID: C1_T1)
DEBUG (MainThread) [custom_components.uponor.sensor] Total amount of sensors added: xx
